### PR TITLE
support meson arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # colcon-meson
 
 A colcon extension for building [Meson](https://mesonbuild.com) packages.
+
+## Passing Meson arguments
+
+Arguments can be passed to `meson setup` via `--meson-args`:
+1. set build options defined in `meson_options.txt`:
+    ```sh
+    colcon build --packages-select $PACKAGE --meson-args \
+        -D$ARG1=$PARAM1 \
+        -D$ARG2=$PARAM2
+    ```
+2. set the build type:
+    ```sh
+    colcon build --packages-select $PACKAGE --meson-args \
+        --buildtype=debugoptimized
+    ```
+
+See `meson setup -h` for a detailed list of arguments.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A colcon extension for building [Meson](https://mesonbuild.com) packages.
 
+Install from the Python Package Index via:
+```sh
+pip install colcon-meson
+```
+
 ## Passing Meson arguments
 
 Arguments can be passed to `meson setup` via `--meson-args`:

--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -165,7 +165,9 @@ class MesonBuildTask(TaskExtensionPoint):
         if args.meson_args:
             cmd += args.meson_args
 
-        completed = await run(self.context, cmd, cwd=args.build_base, env=env)
+        completed = await run(self.context, cmd, cwd=args.build_base, env=env, capture_output="stdout")
+        if completed.returncode:
+            logger.error("\n"+completed.stdout.decode('utf-8'))
         return completed.returncode
 
     async def _build(self, args, env, *, additional_targets=None):

--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import shutil
 import json
 
+from mesonbuild import coredata
+from mesonbuild.mesonmain import CommandLineParser
+
 from colcon_core.environment import create_environment_scripts
 from colcon_core.logging import colcon_logger
 from colcon_core.shell import get_command_environment
@@ -20,11 +23,74 @@ def parse_install_targets(target_data):
     return install_targets
 
 
+def cfg_changed(old, new):
+    for p in old.keys() & new.keys():
+        n = new[p]
+        # convert string representations of boolen values
+        if type(old[p]) is bool and type(n) is str:
+            n = bool(n.lower() == "true")
+        if n != old[p]:
+            logger.debug("option '{}' changed from '{}' to '{}'".format(p, old[p], n))
+            return True
+    return False
+
+
+def cfg_diff(old, new):
+    # get changes between old and new configuration
+    k_removed = set(old.keys()) - set(new.keys())
+    k_added = set(new.keys()) - set(old.keys())
+    d_removed = {k: old[k] for k in k_removed}
+    d_added = {k: new[k] for k in k_added}
+    return d_added, d_removed
+
+
+def format_args(args):
+    return {arg.name: args.cmd_line_options[arg] for arg in args.cmd_line_options}
+
+
 class MesonBuildTask(TaskExtensionPoint):
     def __init__(self):
         super().__init__()
 
         self.meson_path = shutil.which("meson")
+        self.parser_setup = CommandLineParser().subparsers.choices["setup"]
+
+    def add_arguments(self, *, parser):
+        parser.add_argument('--meson-args',
+            nargs='*', metavar='*', type=str.lstrip, default=list(),
+            help='Pass arguments to Meson projects.')
+
+    def get_default_args(self, args):
+        margs = list()
+
+        # meson installs by default to architecture specific subdirectories,
+        # e.g. "lib/x86_64-linux-gnu", but the LibraryPathEnvironment hook
+        # only searches within the fist lib level
+        margs += ["--libdir=lib"]
+
+        margs += ["--prefix=" + args.install_base]
+
+        # build in release mode by default
+        margs += ["--buildtype=release"]
+
+        # positional arguments for 'builddir' and 'sourcedir'
+        margs += [args.build_base]
+        margs += [args.path]
+
+        return margs
+
+    def meson_parse_cmdline(self, cmdline):
+        args = self.parser_setup.parse_args(cmdline)
+        coredata.parse_cmd_line_options(args)
+        return args
+
+    def meson_format_cmdline(self, cmdline):
+        return format_args(self.meson_parse_cmdline(cmdline))
+
+    def meson_format_cmdline_file(self, builddir):
+        args = self.meson_parse_cmdline([])
+        coredata.read_cmd_line_file(builddir, args)
+        return format_args(args)
 
     async def build(self, *, additional_hooks=None, skip_hook_creation=False,
                     environment_callback=None, additional_targets=None):
@@ -70,24 +136,54 @@ class MesonBuildTask(TaskExtensionPoint):
     async def _reconfigure(self, args, env):
         self.progress('meson')
 
-        cache = Path(args.build_base) / "meson-private" / "build.dat"
-        run_configure = not cache.exists()
-        if not run_configure:
-            buildfile = cache.parent / 'build.ninja'
-            run_configure = not buildfile.exists()
+        # set default arguments
+        marg_def = self.get_default_args(args)
+        # parse default arguments as dict
+        defcfg = self.meson_format_cmdline(marg_def)
 
-        if not run_configure:
+        buildfile = Path(args.build_base) / "build.ninja"
+        configfile = Path(args.build_base) / "meson-info" / "intro-buildoptions.json"
+
+        run_init_setup = not buildfile.exists()
+
+        config_changed = False
+
+        if not run_init_setup:
+            newcfg = self.meson_format_cmdline(args.meson_args)
+            oldcfg = self.meson_format_cmdline_file(args.build_base)
+            # remove default arguments
+            for arg in oldcfg.keys() & defcfg.keys():
+                if oldcfg[arg] == defcfg[arg]:
+                    del oldcfg[arg]
+
+            # get arguments that are missing from the previous command line
+            removed = cfg_diff(oldcfg, newcfg)[1]
+
+            # restore default values if argument was removed
+            for arg in removed.keys():
+                if arg in defcfg and removed[arg] != defcfg[arg]:
+                    newcfg[arg] = defcfg[arg]
+
+            # parse old configuration from meson cache
+            assert(configfile.exists())
+            with open(configfile, 'r') as f:
+                mesoncfg = {arg["name"]: arg["value"] for arg in json.load(f)}
+
+            # check if command line arguments would change the current meson settings
+            config_changed = cfg_changed(mesoncfg, newcfg)
+
+        if not run_init_setup and not config_changed:
             return
 
         cmd = list()
         cmd += [self.meson_path]
         cmd += ["setup"]
-        # the LibraryPathEnvironment hook only searches within the fist lib level
-        # meson installs by default to "lib/x86_64-linux-gnu"
-        cmd += ["--libdir=lib"]
-        cmd += ["--prefix=" + args.install_base]
-        cmd += [args.build_base] # builddir
-        cmd += [args.path] # sourcedir
+        cmd.extend(marg_def)
+        if config_changed:
+            logger.info("reconfiguring '{}' because configuration changed".format(self.context.pkg.name))
+            cmd += ["--reconfigure"]
+        if args.meson_args:
+            cmd += args.meson_args
 
         completed = await run(self.context, cmd, cwd=args.build_base, env=env)
         return completed.returncode

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.0.1
+version = 0.2.0
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch


### PR DESCRIPTION
This adds Meson argument support using the new colcon argument `--meson-args`:
- support all `meson setup` arguments (see `meson setup -h` for details)
- support user options (`-D$ARG1=$PARAM1`)
- automatically remove installed files if their install targets get removed
- add installation and usage instructions

This can then be used in combination with colcon mixins. For example, the [`libcamera`](https://libcamera.org) Meson project can be used with the mixin file `colcon.meta`:
```json
{
  "names": {
    "libcamera": { "meson-args": ["--auto-features=disabled", "-Dtest=false"] }
  }
}
```
to disable all features (Meson core option) and to disable tests (libcamera specific option).