### PR TITLE
support ros.meson

### DIFF
--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -220,3 +220,13 @@ class MesonBuildTask(TaskExtensionPoint):
         cmd += ["install"]
 
         return await run(self.context, cmd, cwd=args.build_base, env=env)
+
+
+class RosMesonBuildTask(TaskExtensionPoint):
+    def __init__(self):
+        super().__init__()
+
+    async def build(self):
+        meson_extension = MesonBuildTask()
+        meson_extension.set_context(context=self.context)
+        rc = await meson_extension.build()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,4 @@ colcon_core.package_identification =
     meson = colcon_meson.identification:MesonPackageIdentification
 colcon_core.task.build =
     meson = colcon_meson.build:MesonBuildTask
+    ros.meson = colcon_meson.build:RosMesonBuildTask


### PR DESCRIPTION
This creates a thin wrapper class as entry point for `ros.meson` packages
in order to handle meson packages with a `package.xml`.

Meson arguments are passed to `ros.meson` and `meson` packages in the same way via `--meson-args`. E.g. the build type of a `ros.meson` package can be overridden by:
```
colcon build --meson-args --buildtype=debug
```