### PR TITLE
forward rc in RosMesonBuildTask

### DIFF
--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -105,10 +105,9 @@ class MesonBuildTask(TaskExtensionPoint):
         if rc:
             return rc
 
-
-        completed = await self._install(args, env)
-        if completed.returncode:
-            return completed.returncode
+        rc = await self._install(args, env)
+        if rc:
+            return rc
 
         if not skip_hook_creation:
             create_environment_scripts(self.context.pkg, args, additional_hooks=additional_hooks)
@@ -219,7 +218,9 @@ class MesonBuildTask(TaskExtensionPoint):
         cmd += [self.meson_path]
         cmd += ["install"]
 
-        return await run(self.context, cmd, cwd=args.build_base, env=env)
+        completed = await run(self.context, cmd, cwd=args.build_base, env=env)
+        if completed.returncode:
+            return completed.returncode
 
 
 class RosMesonBuildTask(TaskExtensionPoint):

--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -231,3 +231,5 @@ class RosMesonBuildTask(TaskExtensionPoint):
         meson_extension = MesonBuildTask()
         meson_extension.set_context(context=self.context)
         rc = await meson_extension.build()
+        if rc:
+            return rc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.3.0
+version = 0.3.1
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core
+  colcon-core >= 0.10.0
   colcon-library-path
   meson >= 0.54.0
 packages = find:


### PR DESCRIPTION
PR https://github.com/colcon/colcon-meson/pull/3 added support for `ros.meson` packages via a thin wrapper `RosMesonBuildTask`. This did not return the rc in method `build` and hence build errors would not be recognised. Fix this by forwarding the rc just like in the other cases.