### PR TITLE
fix meson minimum version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.3.1
+version = 0.3.2
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch
@@ -17,7 +17,7 @@ keywords = colcon
 install_requires =
   colcon-core >= 0.10.0
   colcon-library-path
-  meson >= 0.54.0
+  meson >= 0.60.0
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
`InterpreterBase` is only available in meson version 0.60.0 and upwards. Using lower versions will result in:
```
ModuleNotFoundError: No module named 'mesonbuild.interpreterbase.interpreterbase'; 'mesonbuild.interpreterbase' is not a package
```
or:
```
ImportError: cannot import name 'IterableObject' from 'mesonbuild.interpreterbase'
```

Fix this by requiring at least version 0.60.0.