### PR TITLE
fix args conversion

### DIFF
--- a/colcon_meson/build.py
+++ b/colcon_meson/build.py
@@ -36,6 +36,10 @@ def cfg_diff(old, new):
     return d_added, d_removed
 
 
+def format_args(args):
+    return {arg.name: args.cmd_line_options[arg] for arg in args.cmd_line_options}
+
+
 class MesonBuildTask(TaskExtensionPoint):
     def __init__(self):
         super().__init__()
@@ -73,12 +77,12 @@ class MesonBuildTask(TaskExtensionPoint):
         return args
 
     def meson_format_cmdline(self, cmdline):
-        return vars(self.meson_parse_cmdline(cmdline))
+        return format_args(self.meson_parse_cmdline(cmdline))
 
     def meson_format_cmdline_file(self, builddir):
         args = self.meson_parse_cmdline([])
         coredata.read_cmd_line_file(builddir, args)
-        return vars(args)
+        return format_args(args)
 
     async def build(self, *, additional_hooks=None, skip_hook_creation=False,
                     environment_callback=None, additional_targets=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.4.0
+version = 0.4.1
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch


### PR DESCRIPTION
Commit 037a9917bbc12c67004ff781f0d006c7faccf4ee tried to simplify the conversion from an `OrderedDict` of `OptionKey`s to a regular `dict`. This failed to extract the value from the `OptionKey`. This PR just reverts that commit.