### PR TITLE
add stdeb and publish-python configuration files

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -1,0 +1,14 @@
+artifacts:
+  - type: wheel
+    uploads:
+      - type: pypi
+  - type: stdeb
+    uploads:
+      - type: packagecloud
+        config:
+          repository: dirk-thomas/colcon
+          distributions:
+            - ubuntu:focal
+            - ubuntu:jammy
+            - debian:buster
+            - debian:bullseye

--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -8,7 +8,4 @@ artifacts:
         config:
           repository: dirk-thomas/colcon
           distributions:
-            - ubuntu:focal
             - ubuntu:jammy
-            - debian:buster
-            - debian:bullseye

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,5 @@
 [colcon-meson]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.10.0), python3-colcon-library-path
-Recommends3: meson, ninja-build
-Suite: focal jammy buster bullseye
+Depends3: meson (>= 0.60.0), python3-colcon-core (>= 0.10.0), python3-colcon-library-path
+Suite: jammy
 X-Python3-Version: >= 3.6

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,6 @@
+[colcon-meson]
+No-Python2:
+Depends3: python3-colcon-core (>= 0.10.0), python3-colcon-library-path
+Recommends3: meson, ninja-build
+Suite: focal jammy buster bullseye
+X-Python3-Version: >= 3.6


### PR DESCRIPTION
Add configuration files for [stdeb](https://pypi.org/project/stdeb/) and [publish-python](https://github.com/dirk-thomas/publish-python) in order to publish `colcon-meson` as a Debian package. This is required to eventually build meson packages on the ROS build farm.