### PR TITLE
support meson 1.3 private API for getting function name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.4.2
+version = 0.4.3
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch


### PR DESCRIPTION
`colcon-meson` is using private meson API to access metadata about the project. This API breaks with version 1.3. Support the old and new API with a type switch for accessing the function name.