### PR TITLE
add unit tests for identification via different Meson versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,26 @@ on:
 jobs:
   pytest:
     uses: colcon/ci/.github/workflows/pytest.yaml@main
+
+  meson:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [0.61, 1.3, 'latest']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
+
+      - run: pip install -e .[test]
+
+      - run: pip install meson==${{ matrix.version }}
+        if: ${{ matrix.version != 'latest' }}
+
+      - run: pip install --upgrade meson
+        if: ${{ matrix.version == 'latest' }}
+
+      - run: pytest

--- a/colcon_meson/identification.py
+++ b/colcon_meson/identification.py
@@ -59,7 +59,7 @@ class CustomInterpreter(InterpreterBase):
 
     def _function_call(self, node: mparser.FunctionNode) -> typing.Optional[InterpreterObject]:
         node_func_name = f"{type(node.func_name).__module__}.{type(node.func_name).__qualname__}"
-        if node_func_name == "str":
+        if node_func_name == "builtins.str":
             # meson <= 1.2
             func_name = node.func_name
         elif node_func_name == "mesonbuild.mparser.IdNode":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = colcon-meson
-version = 0.4.3
+version = 0.4.4
 project_urls =
     GitHub = https://github.com/colcon/colcon-meson
 author = Christian Rauch

--- a/test/meson_test_project/meson.build
+++ b/test/meson_test_project/meson.build
@@ -1,0 +1,13 @@
+project(
+  'meson_test_project', 'c',
+  version : '0.1',
+  default_options : ['warning_level=3']
+)
+
+exe = executable(
+  'meson_test_project',
+  'meson_test_project.c',
+  install : true
+)
+
+test('basic', exe)

--- a/test/meson_test_project/meson_test_project.c
+++ b/test/meson_test_project/meson_test_project.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+#define PROJECT_NAME "meson_test_project"
+
+int main(int argc, char **argv) {
+    if(argc != 1) {
+        printf("%s takes no arguments.\n", argv[0]);
+        return 1;
+    }
+    printf("This is project %s.\n", PROJECT_NAME);
+    return 0;
+}

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -7,6 +7,7 @@ builddir
 buildfile
 buildoptions
 buildtype
+builtins
 cmdline
 codeblock
 colcon

--- a/test/test_identification.py
+++ b/test/test_identification.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Christian Rauch
+# Licensed under the Apache License, Version 2.0
+
+import os
+
+from colcon_core.package_descriptor import PackageDescriptor
+from colcon_meson.identification import MesonPackageIdentification
+
+
+test_project_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'meson_test_project',
+)
+
+
+def test_capital_case():
+    mpi = MesonPackageIdentification()
+    desc = PackageDescriptor(test_project_path)
+    mpi.identify(desc)
+    assert desc.type == 'meson'
+    assert desc.name == 'meson_test_project'


### PR DESCRIPTION
This adds a unit test for the Meson project identification testing different internal Meson API versions.

This PR is also adding a fix for compatibility with older Meson versions.

Test failure without fix: https://github.com/colcon/colcon-meson/actions/runs/8622256738/job/23633000279

Test pass with fix: https://github.com/colcon/colcon-meson/actions/runs/8622316979/job/23633180914